### PR TITLE
Scaling avg hand x

### DIFF
--- a/Yoga_PoseDetection/test.py
+++ b/Yoga_PoseDetection/test.py
@@ -217,6 +217,11 @@ if __name__ == '__main__':
         PL._fps_visualization(body_image, display_fps)
         PL._fps_visualization(landmark_image, display_fps)
 
+
+        # body_imageとlandmark_imageに線を描画
+        cv.line(body_image, (170, 0), (170, image_height), (0, 0, 255), 3)
+        cv.line(body_image, (image_width - 170, 0), (image_width-170, image_height), (0, 0, 255), 3)
+
         
         cv.imshow('Body', body_image)
         cv.imshow('Landmark', landmark_image)

--- a/Yoga_PoseDetection/test_detection.py
+++ b/Yoga_PoseDetection/test_detection.py
@@ -132,10 +132,16 @@ class Detection:
         # 小数点以下切り捨て
         avg_hand_x = math.floor(avg_hand_x)
 
-        if(avg_hand_x < 0):
-            avg_hand_x = 0
-        elif(avg_hand_x > 100):
-            avg_hand_x = 100
+        # 30~70の範囲内に収める
+        if(avg_hand_x < 30):
+            avg_hand_x = 30
+        elif(avg_hand_x > 70):
+            avg_hand_x = 70
+
+        # 30~70の範囲内に収めた値を0~100の範囲にスケーリング
+        avg_hand_x = (avg_hand_x - 30) * 100 / 40
+        # 小数点以下切り捨て
+        avg_hand_x = math.floor(avg_hand_x)
         
         # 送信
         self.send_udp_data(str(avg_hand_x))


### PR DESCRIPTION
トランポリンの上で木のポーズをとることを想定した難易度調整として、手の位置のスケーリングを行う。

今までは、画面の両端を傾きの最大値として、0〜100の範囲で数値を送信していたが、
このプルリクでは、30〜70にスケーリングした。Unityには、30が0, 70が100として値を送信した。

Unity側の変更は必要なし。